### PR TITLE
task: set neos required versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "description": "Plugin providing a bootstrap 4 form preset",
     "license": "MIT",
     "require": {
-        "neos/flow": "^5.0 || ^6.0",
-        "neos/neos": "^4.0 || ^5.0"
+        "neos/neos": "^7.0 || ^8.0"
     },
     "extra": {
         "neos": {
@@ -87,7 +86,21 @@
             "Neos.Fusion-20180211184832",
             "Neos.Flow-20180415105700",
             "Neos.Neos-20180907103800",
-            "Neos.Neos.Ui-20190319094900"
+            "Neos.Neos.Ui-20190319094900",
+            "Neos.SwiftMailer-20161130105617",
+            "Neos.Flow-20190425144900",
+            "Neos.Flow-20190515215000",
+            "Neos.NodeTypes-20190917101945",
+            "Networkteam.Neos.MailObfuscator-20190919145400",
+            "Neos.NodeTypes-20200120114136",
+            "Neos.Flow-20200813181400",
+            "Neos.Flow-20201003165200",
+            "Neos.Flow-20201109224100",
+            "Neos.Flow-20201205172733",
+            "Neos.Flow-20201207104500",
+            "Neos.Neos-20220318111600",
+            "Neos.Flow-20220318174300",
+            "Neos.Fusion-20220326120900"
         ]
     }
 }


### PR DESCRIPTION
Please add new tag. Just raising the required version. This would still run with Neos 5, but not with Neos 4. To have a clear cut, I would tag a new major version never the less. 